### PR TITLE
fix build script to copy deploy jar correctly

### DIFF
--- a/client_vscode/src/main/extension.ts
+++ b/client_vscode/src/main/extension.ts
@@ -10,6 +10,7 @@ interface IExtensionVars {
 }
 
 const MESSAGES = {
+  buildifierNotFound: "Could not find the buildifier binary, would you like to install it now?",
   init: "Starting up Bazel language server...",
   initFailed: "The Bazel extension failed to start.",
   invalidJava: "The bazel.java.home setting does not point to a valid JDK.",
@@ -181,6 +182,15 @@ function startServer(): void {
         // Start the server.
         ext.context.subscriptions.push(langClient.start());
         ext.langClient = langClient;
+
+        // Message box for installing buildifer binaries
+        // vscode.window.showInformationMessage(MESSAGES.buildifierNotFound, ...["Yes"])
+        // .then((selection) => {
+        //   console.log(selection);
+        //   if (selection === "Yes") {
+        //     // send request to server to install the binary in a specified path
+        //   }
+        // });
       });
     },
   );

--- a/client_vscode/src/main/extension.ts
+++ b/client_vscode/src/main/extension.ts
@@ -10,7 +10,6 @@ interface IExtensionVars {
 }
 
 const MESSAGES = {
-  buildifierNotFound: "Could not find the buildifier binary, would you like to install it now?",
   init: "Starting up Bazel language server...",
   initFailed: "The Bazel extension failed to start.",
   invalidJava: "The bazel.java.home setting does not point to a valid JDK.",
@@ -182,15 +181,6 @@ function startServer(): void {
         // Start the server.
         ext.context.subscriptions.push(langClient.start());
         ext.langClient = langClient;
-
-        // Message box for installing buildifer binaries
-        // vscode.window.showInformationMessage(MESSAGES.buildifierNotFound, ...["Yes"])
-        // .then((selection) => {
-        //   console.log(selection);
-        //   if (selection === "Yes") {
-        //     // send request to server to install the binary in a specified path
-        //   }
-        // });
       });
     },
   );

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -43,7 +43,7 @@ then
         
         # Move the language server into the client bin (for development purposes).
         echo "Migrating server jar..."
-        mkdir bin 2> /dev/null || true
+        mkdir -p client_vscode/bin 2> /dev/null || true
         cp bazel-bin/server/bazel_ls_deploy.jar client_vscode/bin/bazel_ls_deploy.jar
  
         echo "Building client..."

--- a/server/src/main/java/server/BazelServices.java
+++ b/server/src/main/java/server/BazelServices.java
@@ -32,6 +32,8 @@ public class BazelServices implements TextDocumentService, WorkspaceService, Lan
         logger.info("Did Open");
         logger.info(params.toString());
         DocumentTracker.getInstance().didOpen(params);
+        languageClient.showMessage(new MessageParams(MessageType.Info, "hello world"));
+
 //        documentTracker.didOpen(params);
 
 //        try {

--- a/server/src/main/java/server/BazelServices.java
+++ b/server/src/main/java/server/BazelServices.java
@@ -32,7 +32,6 @@ public class BazelServices implements TextDocumentService, WorkspaceService, Lan
         logger.info("Did Open");
         logger.info(params.toString());
         DocumentTracker.getInstance().didOpen(params);
-        languageClient.showMessage(new MessageParams(MessageType.Info, "hello world"));
 
 //        documentTracker.didOpen(params);
 


### PR DESCRIPTION
Only one change in the build.sh file to mkdir in the correct directory, and then copy the bazel_ls_deploy.jar over. 
The other two changes are temporary and can be removed if pulled (commented out displaying a window when the server starts, and a single line to communicate from the server to the client)