### PR TITLE
Users are now notified of Parsing errors

### DIFF
--- a/server/src/main/java/server/BUILD
+++ b/server/src/main/java/server/BUILD
@@ -15,6 +15,7 @@ java_library(
         "//server/src/main/java/server/formatting",
         "//server/src/main/java/server/utils",
         "//server/src/main/java/server/workspace",
+        "//server/src/main/java/server/bazel/cli",
         "//third_party/java:gson",
         "//third_party/java:guava",
         "//third_party/java:log4j",

--- a/server/src/main/java/server/BazelLanguageServer.java
+++ b/server/src/main/java/server/BazelLanguageServer.java
@@ -7,6 +7,7 @@ import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.services.*;
 import server.workspace.ProjectFolder;
 import server.workspace.Workspace;
+import server.bazel.cli.BazelServerException;
 
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
@@ -36,7 +37,18 @@ public class BazelLanguageServer implements LanguageServer, LanguageClientAware 
     logger.info(String.format("Starting up bazel language server with params:\n\"%s\"", params));
 
         initializeWorkspaceRoot(params);
-        Workspace.getInstance().initializeWorkspace();
+        try{
+            Workspace.getInstance().initializeWorkspace();
+            logger.info("workspace initialized");
+
+        } catch( BazelServerException e){
+            logger.info("workspace error");
+            String message = "Bazel Extension Failed to parse due to BUILD Parsing errors:\n";
+            String fix = "Please fix the Bazel Syntax error then restart the Extension\n";
+            bazelServices.sendMessageToClient(MessageType.Error, message + fix + e.getMessage());
+            
+        }
+        
 
         return CompletableFuture.completedFuture(specifyServerCapabilities());
     }

--- a/server/src/main/java/server/BazelServices.java
+++ b/server/src/main/java/server/BazelServices.java
@@ -205,4 +205,8 @@ public class BazelServices implements TextDocumentService, WorkspaceService, Lan
             return CompletableFuture.completedFuture(new ArrayList<TextEdit>());
         }
     }
+
+    public void sendMessageToClient(MessageType type,String message){
+        languageClient.showMessage(new MessageParams(type, message));
+    }
 }

--- a/server/src/main/java/server/workspace/Workspace.java
+++ b/server/src/main/java/server/workspace/Workspace.java
@@ -67,7 +67,7 @@ public class Workspace {
         workspaceFolders.removeAll(folders);
     }
 
-    public void initializeWorkspace() {
+    public void initializeWorkspace() throws BazelServerException {
         List<BuildTarget> buildTargets;
         List<SourceFile> sourceFiles;
         try {
@@ -77,6 +77,7 @@ public class Workspace {
             sourceFiles.forEach(this::addSourceToTree);
         } catch (BazelServerException e) {
             logger.info(e.getMessage());
+            throw e;
         }
     }
 

--- a/server/src/test/java/server/workspace/WorkspaceTest.java
+++ b/server/src/test/java/server/workspace/WorkspaceTest.java
@@ -48,7 +48,12 @@ public class WorkspaceTest {
         mockBuildTargetList.add(new BuildTarget(Paths.get("main/java"), "test_2", "test"));
         mockBuildTargetList.add(new BuildTarget(Paths.get("main/java/test"), "test_3", "test"));
 
-        classUnderTest.initializeWorkspace();
+        try{
+            classUnderTest.initializeWorkspace();
+        } catch( BazelServerException e){
+            System.out.println(e.getMessage());
+        }
+        
         WorkspaceTree tree = classUnderTest.getWorkspaceTree();
         WorkspaceTree.Node node = tree.getRoot();
         checkChildrenCount(node, 1);
@@ -81,8 +86,11 @@ public class WorkspaceTest {
         mockBuildTargetList.add(new BuildTarget(Paths.get("main"), "test_1", "test"));
         mockBuildTargetList.add(new BuildTarget(Paths.get("main"), "test_2", "test"));
         mockBuildTargetList.add(new BuildTarget(Paths.get("main"), "test_3", "test"));
-
-        classUnderTest.initializeWorkspace();
+        try{
+            classUnderTest.initializeWorkspace();
+        } catch( BazelServerException e){
+            System.out.println(e.getMessage());
+        }
         WorkspaceTree tree = classUnderTest.getWorkspaceTree();
         Optional<WorkspaceTree.Node> node = tree.getRoot().getChild("main");
         Assert.assertTrue(node.isPresent());


### PR DESCRIPTION
If a Bazel Syntax error causes the Workspace tree parsing to fail, The user will now receive a notification that contains the error message that has the location of the error, and the steps to get our extension working. 

So instead of silently failing. Our extension users will know why the Bazel Extension is not working. 