### PR TITLE
Fix code lense to work on java 1.8

### DIFF
--- a/server/src/main/java/server/codelens/CodeLensProvider.java
+++ b/server/src/main/java/server/codelens/CodeLensProvider.java
@@ -2,7 +2,7 @@ package server.codelens;
 
 import java.io.File;
 import java.net.URI;
-import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
@@ -89,7 +89,7 @@ public class CodeLensProvider {
 
         List<BuildTarget> targets = null;
         try {
-            targets = api.findPossibleTargetsForPath(Path.of(path));
+            targets = api.findPossibleTargetsForPath(Paths.get(path));
         }
         catch(WorkspaceAPIException e) {
             logger.error(e + " in: " + path);


### PR DESCRIPTION
Changed a Path.of to Paths.get so that the code works with java 1.8
I'm not sure how this passed the Checks. I wasn't able to build and run the project without fixing this line. 